### PR TITLE
Update HDU10

### DIFF
--- a/force-app/main/default/objects/Obra__c/fields/EstadoObra__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/EstadoObra__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>EstadoObra__c</fullName>
     <externalId>false</externalId>
     <label>Estado de la Obra</label>
-    <required>false</required>
+    <required>true</required>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
@@ -13,7 +13,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Levantamiento / Validación de Información</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Levantamiento / Validación de Información</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Obra__c/fields/Pais__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/Pais__c.field-meta.xml
@@ -3,7 +3,6 @@
     <fullName>Pais__c</fullName>
     <deleteConstraint>Restrict</deleteConstraint>
     <externalId>false</externalId>
-    <inlineHelpText>01/06</inlineHelpText>
     <label>Pais</label>
     <lookupFilter>
         <active>true</active>
@@ -26,12 +25,12 @@
         <filterItems>
             <field>udcDetallada__c.codigoUDC__c</field>
             <operation>equals</operation>
-            <value>01/06</value>
+            <value>00/CN</value>
         </filterItems>
         <filterItems>
             <field>udcDetallada__c.tipoUDC__r.ambitoUDC__c</field>
             <operation>equals</operation>
-            <value>Clientes</value>
+            <value>Contactos</value>
         </filterItems>
         <isOptional>false</isOptional>
     </lookupFilter>

--- a/force-app/main/default/objects/Obra__c/fields/ParticipacionVentas__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/ParticipacionVentas__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ParticipacionVentas__c</fullName>
     <externalId>false</externalId>
-    <formula>VentasDirectas__c  +  VentasIndirectas__c  +  VentasReferenciales__c  /  PotencialEstimadoVenta__c</formula>
+    <formula>( VentasDirectas__c  +  VentasIndirectas__c  +  VentasReferenciales__c )  /  ( PotencialEstimadoVenta__c )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Participación de Ventas</label>
     <precision>18</precision>

--- a/force-app/main/default/objects/Obra__c/fields/Provincia__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/Provincia__c.field-meta.xml
@@ -3,7 +3,6 @@
     <fullName>Provincia__c</fullName>
     <deleteConstraint>Restrict</deleteConstraint>
     <externalId>false</externalId>
-    <inlineHelpText>01/07</inlineHelpText>
     <label>Provincia</label>
     <lookupFilter>
         <active>true</active>

--- a/force-app/main/default/objects/Obra__c/fields/Region__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/Region__c.field-meta.xml
@@ -3,7 +3,6 @@
     <fullName>Region__c</fullName>
     <deleteConstraint>Restrict</deleteConstraint>
     <externalId>false</externalId>
-    <inlineHelpText>01/11</inlineHelpText>
     <label>Región</label>
     <lookupFilter>
         <active>true</active>

--- a/force-app/main/default/objects/Obra__c/fields/VentasDirectas__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/VentasDirectas__c.field-meta.xml
@@ -2,12 +2,10 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>VentasDirectas__c</fullName>
     <externalId>false</externalId>
-    <formula>CodigoObra__c  +  direccionGeorreferenciada__Latitude__s</formula>
-    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Ventas Directas</label>
     <precision>18</precision>
     <required>false</required>
-    <scale>2</scale>
+    <scale>0</scale>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Currency</type>

--- a/force-app/main/default/objects/Obra__c/fields/VentasIndirectas__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/VentasIndirectas__c.field-meta.xml
@@ -2,12 +2,10 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>VentasIndirectas__c</fullName>
     <externalId>false</externalId>
-    <formula>CodigoObra__c  +  direccionGeorreferenciada__Latitude__s</formula>
-    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Ventas Indirectas</label>
     <precision>18</precision>
     <required>false</required>
-    <scale>2</scale>
+    <scale>0</scale>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Currency</type>

--- a/force-app/main/default/objects/Obra__c/fields/VentasReferenciales__c.field-meta.xml
+++ b/force-app/main/default/objects/Obra__c/fields/VentasReferenciales__c.field-meta.xml
@@ -2,12 +2,10 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>VentasReferenciales__c</fullName>
     <externalId>false</externalId>
-    <formula>CodigoObra__c  +  direccionGeorreferenciada__Latitude__s</formula>
-    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Ventas Referenciales</label>
     <precision>18</precision>
     <required>false</required>
-    <scale>2</scale>
+    <scale>0</scale>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Currency</type>

--- a/force-app/main/default/permissionsets/ProyectoObra.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/ProyectoObra.permissionset-meta.xml
@@ -187,6 +187,10 @@
         <object>RelacionObra__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
+    <pageAccesses>
+        <apexPage>showGoogleObraMap</apexPage>
+        <enabled>true</enabled>
+    </pageAccesses>
     <recordTypeVisibilities>
         <recordType>Opportunity.Estimacion</recordType>
         <visible>true</visible>

--- a/force-app/main/default/permissionsets/ProyectoObra.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/ProyectoObra.permissionset-meta.xml
@@ -32,11 +32,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>Obra__c.EstadoObra__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
         <field>Obra__c.Lead__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/manifest/PackageHU.xml
+++ b/manifest/PackageHU.xml
@@ -1,42 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
 	<types>
-		<members>Obra__c.CodigoObras__c</members>
-		<members>Obra__c.Compania__c</members>
-		<members>Obra__c.Moneda__c</members>
+		<members>Obra__c.EstadoObra__c</members>
 		<members>Obra__c.Pais__c</members>
-		<members>Obra__c.PotencialEstimadoVenta__c</members>
+		<members>Obra__c.ParticipacionVentas__c</members>
 		<members>Obra__c.Provincia__c</members>
 		<members>Obra__c.Region__c</members>
+		<members>Obra__c.VentasDirectas__c</members>
+		<members>Obra__c.VentasIndirectas__c</members>
+		<members>Obra__c.VentasReferenciales__c</members>
 		<name>CustomField</name>
-	</types>
-	<types>
-		<members>ObraPaginaRegistro</members>
-		<name>FlexiPage</name>
-	</types>
-	<types>
-		<members>CreateQuoteFromObras</members>
-		<name>Flow</name>
-	</types>
-	<types>
-		<members>CreateQuoteFromObras</members>
-		<name>FlowDefinition</name>
-	</types>
-	<types>
-		<members>Obra__c-Formato Obras</members>
-		<name>Layout</name>
-	</types>
-	<types>
-		<members>currentLocationLWC</members>
-		<name>LightningComponentBundle</name>
 	</types>
 	<types>
 		<members>ProyectoObra</members>
 		<name>PermissionSet</name>
-	</types>
-	<types>
-		<members>Obra__c.CampoNoEditablePotencialEstimadoVenta</members>
-		<name>ValidationRule</name>
 	</types>
 	<version>58.0</version>
 </Package>


### PR DESCRIPTION
- Nuevos campos creados en Obra
VentasDirectas__c
VentasIndirectas__c
VentasReferenciales__c 

- Campos actualizados por filtro nuevo
Participación de Ventas, ya que contiene un filtro con esos campos eliminados en test
Pais

- Obligatoriedad a nivel de campo
   Estado de la obra

- Modificación en campos, no deben contener texto de ayuda
  Pais, provincia y region
